### PR TITLE
JOB-30658 Add ability to set authorization headers

### DIFF
--- a/GooglePlacesAutocomplete.d.ts
+++ b/GooglePlacesAutocomplete.d.ts
@@ -360,9 +360,14 @@ interface Place {
   geometry: { location: Point };
 }
 
+interface Header {
+  authorization?: string; 
+}
+
 interface RequestUrl {
   url: string;
   useOnPlatform: 'web' | 'all';
+  headers?: Header;
 }
 
 interface GooglePlacesAutocompleteProps {

--- a/GooglePlacesAutocomplete.d.ts
+++ b/GooglePlacesAutocomplete.d.ts
@@ -360,14 +360,10 @@ interface Place {
   geometry: { location: Point };
 }
 
-interface Header {
-  authorization?: string; 
-}
-
 interface RequestUrl {
   url: string;
   useOnPlatform: 'web' | 'all';
-  headers?: Header;
+  headers?: Record<string, string>;
 }
 
 interface GooglePlacesAutocompleteProps {

--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -108,12 +108,10 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
   };
 
   const getRequestHeaders = (requestUrl) => {
-    if(requestUrl) {
-      if (requestUrl.headers) {
-        return requestUrl.headers;
-      } else {
-        return {}
-      }
+    if(requestUrl && requestUrl.headers) {
+      return requestUrl.headers;
+    } else {
+      return {}
     }
   }
 
@@ -134,8 +132,7 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
   };
 
   const setRequestHeaders = (request, headers) => 
-    Object.keys(headers).map((k) => request.setRequestHeader(k, headers[k]))
-  
+    Object.keys(headers).map((headerKey) => request.setRequestHeader(headerKey, headers[headerKey]))
 
   const [stateText, setStateText] = useState('');
   const [dataSource, setDataSource] = useState(buildRowsFromResults([]));
@@ -314,7 +311,6 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
       );
 
       request.withCredentials = requestShouldUseWithCredentials();
-      // request headers must be set after open but before send
       setRequestHeaders(request, headers)
       request.send();
     } else if (rowData.isCurrentLocation === true) {
@@ -474,7 +470,6 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
       request.open('GET', requestUrl);
 
       request.withCredentials = requestShouldUseWithCredentials();
-      // request headers must be set after open but before send
       setRequestHeaders(request, headers)
       
       request.send();
@@ -539,7 +534,6 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
       );
 
       request.withCredentials = requestShouldUseWithCredentials();
-      // request headers must be set after open but before send
       setRequestHeaders(request, headers)
       
       request.send();

--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -107,6 +107,16 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
     return [...res, ...results];
   };
 
+  const getRequestHeaders = (requestUrl) => {
+    if(requestUrl) {
+      if (requestUrl.headers) {
+        return requestUrl.headers;
+      } else {
+        return {}
+      }
+    }
+  }
+
   const getRequestUrl = (requestUrl) => {
     if (requestUrl) {
       if (requestUrl.useOnPlatform === 'all') {
@@ -123,12 +133,17 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
     }
   };
 
+  const setRequestHeaders = (request, headers) => 
+    Object.keys(headers).map((k) => request.setRequestHeader(k, headers[k]))
+  
+
   const [stateText, setStateText] = useState('');
   const [dataSource, setDataSource] = useState(buildRowsFromResults([]));
   const [listViewDisplayed, setListViewDisplayed] = useState(
     props.listViewDisplayed === 'auto' ? false : props.listViewDisplayed,
   );
   const [url] = useState(getRequestUrl(props.requestUrl));
+  const [headers] = useState(getRequestHeaders(props.requestUrl));
 
   const inputRef = useRef();
 
@@ -299,7 +314,8 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
       );
 
       request.withCredentials = requestShouldUseWithCredentials();
-
+      // request headers must be set after open but before send
+      setRequestHeaders(request, headers)
       request.send();
     } else if (rowData.isCurrentLocation === true) {
       // display loader
@@ -458,7 +474,9 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
       request.open('GET', requestUrl);
 
       request.withCredentials = requestShouldUseWithCredentials();
-
+      // request headers must be set after open but before send
+      setRequestHeaders(request, headers)
+      
       request.send();
     } else {
       _results = [];
@@ -521,7 +539,9 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
       );
 
       request.withCredentials = requestShouldUseWithCredentials();
-
+      // request headers must be set after open but before send
+      setRequestHeaders(request, headers)
+      
       request.send();
     } else {
       _results = [];
@@ -871,6 +891,9 @@ GooglePlacesAutocomplete.propTypes = {
   requestUrl: PropTypes.shape({
     url: PropTypes.string,
     useOnPlatform: PropTypes.oneOf(['web', 'all']),
+    headers: PropTypes.shape({
+      authorization: PropTypes.string,
+    })
   }),
   styles: PropTypes.object,
   suppressDefaultStyles: PropTypes.bool,

--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -108,12 +108,12 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
   };
 
   const getRequestHeaders = (requestUrl) => {
-    if(requestUrl && requestUrl.headers) {
+    if (requestUrl && requestUrl.headers) {
       return requestUrl.headers;
     } else {
-      return {}
+      return {};
     }
-  }
+  };
 
   const getRequestUrl = (requestUrl) => {
     if (requestUrl) {
@@ -132,8 +132,10 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
   };
 
   const setRequestHeaders = (request, headers) => {
-    Object.keys(headers).map((headerKey) => request.setRequestHeader(headerKey, headers[headerKey]));
-  }
+    Object.keys(headers).map((headerKey) =>
+      request.setRequestHeader(headerKey, headers[headerKey]),
+    );
+  };
 
   const [stateText, setStateText] = useState('');
   const [dataSource, setDataSource] = useState(buildRowsFromResults([]));
@@ -887,7 +889,7 @@ GooglePlacesAutocomplete.propTypes = {
   requestUrl: PropTypes.shape({
     url: PropTypes.string,
     useOnPlatform: PropTypes.oneOf(['web', 'all']),
-    headers: PropTypes.object,
+    headers: PropTypes.objectOf(PropTypes.string),
   }),
   styles: PropTypes.object,
   suppressDefaultStyles: PropTypes.bool,

--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -131,8 +131,9 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
     }
   };
 
-  const setRequestHeaders = (request, headers) => 
-    Object.keys(headers).map((headerKey) => request.setRequestHeader(headerKey, headers[headerKey]))
+  const setRequestHeaders = (request, headers) => {
+    Object.keys(headers).map((headerKey) => request.setRequestHeader(headerKey, headers[headerKey]));
+  }
 
   const [stateText, setStateText] = useState('');
   const [dataSource, setDataSource] = useState(buildRowsFromResults([]));
@@ -311,7 +312,8 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
       );
 
       request.withCredentials = requestShouldUseWithCredentials();
-      setRequestHeaders(request, headers)
+      setRequestHeaders(request, headers);
+
       request.send();
     } else if (rowData.isCurrentLocation === true) {
       // display loader
@@ -470,8 +472,8 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
       request.open('GET', requestUrl);
 
       request.withCredentials = requestShouldUseWithCredentials();
-      setRequestHeaders(request, headers)
-      
+      setRequestHeaders(request, headers);
+
       request.send();
     } else {
       _results = [];
@@ -534,8 +536,8 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
       );
 
       request.withCredentials = requestShouldUseWithCredentials();
-      setRequestHeaders(request, headers)
-      
+      setRequestHeaders(request, headers);
+
       request.send();
     } else {
       _results = [];

--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -887,9 +887,7 @@ GooglePlacesAutocomplete.propTypes = {
   requestUrl: PropTypes.shape({
     url: PropTypes.string,
     useOnPlatform: PropTypes.oneOf(['web', 'all']),
-    headers: PropTypes.shape({
-      authorization: PropTypes.string,
-    })
+    headers: PropTypes.object,
   }),
   styles: PropTypes.object,
   suppressDefaultStyles: PropTypes.bool,

--- a/package.json
+++ b/package.json
@@ -8,10 +8,6 @@
     "lint": "eslint . && prettier --write .",
     "release": "npx release-it"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/GetJobber/react-native-google-places-autocomplete.git"
-  },
   "keywords": [
     "autocomplete",
     "google",


### PR DESCRIPTION
Adds the ability to add headers to the API calls. This will be used to authorize the calls to our proxy server.

Based on https://github.com/FaridSafi/react-native-google-places-autocomplete/pull/660 but made more generic to support arbitrary headers.

To test, you can update the dependency in your jobber-mobile package.json to

`"@jobber/react-native-google-places-autocomplete": "GetJobber/react-native-google-places-autocomplete#JOB-30658/add-auth-headers", `

And then try supplying a header like so:

```
            requestUrl={{
              url: "",
              useOnPlatform: "web",
              headers: {
                "myheader": "test",
              },
            }}
```
