### PR TITLE
JOB-30658 Set headers via a hook so they can be updated after initial render

### DIFF
--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -107,14 +107,6 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
     return [...res, ...results];
   };
 
-  const getRequestHeaders = (requestUrl) => {
-    if (requestUrl && requestUrl.headers) {
-      return requestUrl.headers;
-    } else {
-      return {};
-    }
-  };
-
   const getRequestUrl = (requestUrl) => {
     if (requestUrl) {
       if (requestUrl.useOnPlatform === 'all') {
@@ -143,7 +135,13 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
     props.listViewDisplayed === 'auto' ? false : props.listViewDisplayed,
   );
   const [url] = useState(getRequestUrl(props.requestUrl));
-  const [headers] = useState(getRequestHeaders(props.requestUrl));
+  const [headers, setHeaders] = useState({});
+
+  useEffect(() => {
+    if (props.requestUrl) {
+      setHeaders(props.requestUrl.headers);
+    }
+  }, [props.requestUrl]);
 
   const inputRef = useRef();
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jobber/react-native-google-places-autocomplete",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Customizable Google Places autocomplete component for iOS and Android React-Native apps",
   "main": "GooglePlacesAutocomplete.js",
   "types": "GooglePlacesAutocomplete.d.ts",


### PR DESCRIPTION
# What's in this PR?

Changes the mechanism by which we set the headers to a `useEffect`, to support the case when they are changed after initial render. i.e. in the jobber-mobile case, the access token is retrieved asynchronously and then added to the header.