### PR TITLE
JOB-30658 Add channel to details request

### DIFF
--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -156,7 +156,7 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
   }, []);
   useEffect(() => {
     // Update dataSource if props.predefinedPlaces changed
-    setDataSource(buildRowsFromResults([])) 
+    setDataSource(buildRowsFromResults([]))
   }, [props.predefinedPlaces])
 
   useImperativeHandle(ref, () => ({
@@ -307,6 +307,7 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
             key: props.query.key,
             placeid: rowData.place_id,
             language: props.query.language,
+            channel: props.query.channel,
             ...props.GooglePlacesDetailsQuery,
           }),
       );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jobber/react-native-google-places-autocomplete",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Customizable Google Places autocomplete component for iOS and Android React-Native apps",
   "main": "GooglePlacesAutocomplete.js",
   "types": "GooglePlacesAutocomplete.d.ts",


### PR DESCRIPTION
<!--
Pull Request titles should be in the format:

<JIRA-TICKET> <Descriptive Title>

e.g. JOB-12345 Add a new component for XYZ

- Include the ticket number with proper casing and dashes (i.e. JOB-12345 not Job 12345)
- Don’t include a subtask ticket number
- Don’t put slashes in the title, use spaces instead
- Use normal casing and spacing for the descriptive title

-->

# What's in this PR?

### Why was this PR created?
Using channels will allow us to break down usage by the channels and you can see this  under the billing details in the google cloud platform dashboard if you have the sufficient permission and can see the labels section.  

The two channels are `1` for the `address` on  client create  and then `2` will be used for `Billing address` 

### Quick summary of the changes you made.
- Added `channel` to the details request

### Any necessary explanation of decisions you made
Instead of changing the types for the `GooglePlacesDetailsQuery` I added it to the request similar to how we were using the key and language that are already passed in from the the autocomplete query. 


## Before

Channel was not being passed to the details request

## After

Channel is now being passed to the details request

# QA
needs to be QA'd with this PR https://github.com/GetJobber/jobber-mobile/pull/1021

- [] All user facing strings are properly localed
- [] This has been QA'd by the PR owner
- [] This has been QA'd by an approver

# References/Picture of dog
![swqa7pohk9i31](https://user-images.githubusercontent.com/51097786/117715472-8c7a4980-b195-11eb-9f7c-a79aaef2c90a.jpeg)
