### PR TITLE
JOB-30658 Fix debouncing

### DIFF
--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -483,7 +483,7 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
     }
   };
 
-  const _request = (text, requestUrl) => {
+  const _request = (text, requestUrl, query) => {
     _abortRequests();
     if (supportedPlatform() && text && text.length >= props.minLength) {
       const request = new XMLHttpRequest();
@@ -535,7 +535,7 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
         `${url}/place/autocomplete/json?input=` +
           encodeURIComponent(text) +
           '&' +
-          Qs.stringify(props.query),
+          Qs.stringify(query),
       );
 
       request.withCredentials = requestShouldUseWithCredentials();
@@ -553,7 +553,7 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
 
   const _onChangeText = (text) => {
     setStateText(text);
-    debounceData(text, props.requestUrl);
+    debounceData(text, props.requestUrl, props.query);
   };
 
   const _handleChangeText = (text) => {

--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -123,6 +123,14 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
     }
   };
 
+  const getRequestHeaders = (requestUrl) => {
+    if (requestUrl) {
+      return requestUrl.headers;
+    } else {
+      return {};
+    }
+  };
+
   const setRequestHeaders = (request, headers) => {
     Object.keys(headers).map((headerKey) =>
       request.setRequestHeader(headerKey, headers[headerKey]),
@@ -135,13 +143,6 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
     props.listViewDisplayed === 'auto' ? false : props.listViewDisplayed,
   );
   const [url] = useState(getRequestUrl(props.requestUrl));
-  const [headers, setHeaders] = useState({});
-
-  useEffect(() => {
-    if (props.requestUrl) {
-      setHeaders(props.requestUrl.headers);
-    }
-  }, [props.requestUrl]);
 
   const inputRef = useRef();
 
@@ -313,7 +314,7 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
       );
 
       request.withCredentials = requestShouldUseWithCredentials();
-      setRequestHeaders(request, headers);
+      setRequestHeaders(request, getRequestHeaders(props.requestUrl));
 
       request.send();
     } else if (rowData.isCurrentLocation === true) {
@@ -473,7 +474,7 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
       request.open('GET', requestUrl);
 
       request.withCredentials = requestShouldUseWithCredentials();
-      setRequestHeaders(request, headers);
+      setRequestHeaders(request, getRequestHeaders(props.requestUrl));
 
       request.send();
     } else {
@@ -482,7 +483,7 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
     }
   };
 
-  const _request = (text, url, headers) => {
+  const _request = (text, requestUrl) => {
     _abortRequests();
     if (supportedPlatform() && text && text.length >= props.minLength) {
       const request = new XMLHttpRequest();
@@ -528,6 +529,7 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
         setStateText(props.preProcess(text));
       }
 
+      const url = getRequestUrl(requestUrl);
       request.open(
         'GET',
         `${url}/place/autocomplete/json?input=` +
@@ -537,7 +539,7 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
       );
 
       request.withCredentials = requestShouldUseWithCredentials();
-      setRequestHeaders(request, headers);
+      setRequestHeaders(request, getRequestHeaders(requestUrl));
 
       request.send();
     } else {
@@ -551,7 +553,7 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
 
   const _onChangeText = (text) => {
     setStateText(text);
-    debounceData(text, url, headers);
+    debounceData(text, props.requestUrl);
   };
 
   const _handleChangeText = (text) => {

--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -482,7 +482,7 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
     }
   };
 
-  const _request = (text) => {
+  const _request = (text, url, headers) => {
     _abortRequests();
     if (supportedPlatform() && text && text.length >= props.minLength) {
       const request = new XMLHttpRequest();
@@ -547,11 +547,11 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
   };
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  const debounceData = useMemo(() => debounce(_request, props.debounce), [props.query]);
+  const debounceData = useMemo(() => debounce(_request, props.debounce), [props.debounce]);
 
   const _onChangeText = (text) => {
     setStateText(text);
-    debounceData(text);
+    debounceData(text, url, headers);
   };
 
   const _handleChangeText = (text) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jobber/react-native-google-places-autocomplete",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "Customizable Google Places autocomplete component for iOS and Android React-Native apps",
   "main": "GooglePlacesAutocomplete.js",
   "types": "GooglePlacesAutocomplete.d.ts",


### PR DESCRIPTION
# What's in the this PR

Fixes the dependency list for the memoized debounce function so that it does not recreate it on each re-render. This lets us use the debounce functionality while still having the text controlled by the containing component. This also requires us to pass in the current `requestUrl` to the _request function so the function can be properly memoized.

This PR also optimizes the setting of the `headers` as the previous implementation was causing the state to be updated on every re-render, which is not useful. It was simpler to remove the `headers` from state and just determine them at the time of the request. 

Can test with https://github.com/GetJobber/jobber-mobile/pull/1035