### PR TITLE
JOB-31417 Show listLoaderComponent while loading

### DIFF
--- a/GooglePlacesAutocomplete.d.ts
+++ b/GooglePlacesAutocomplete.d.ts
@@ -394,6 +394,8 @@ interface GooglePlacesAutocompleteProps {
   keyboardShouldPersistTaps?: 'never' | 'always' | 'handled';
   /** use the ListEmptyComponent prop when no autocomplete results are found. */
   listEmptyComponent?: JSX.Element | React.ComponentType<{}>;
+  /** use the ListLoaderComponent prop when the results are loading. */
+  listLoaderComponent?: JSX.Element | React.ComponentType<{}>;
   listUnderlayColor?: string;
   listViewDisplayed?: 'auto' | boolean;
   /** minimum length of text to search */
@@ -437,5 +439,5 @@ export type GooglePlacesAutocompleteRef = {
 
 export const GooglePlacesAutocomplete: React.ForwardRefExoticComponent<
   React.PropsWithoutRef<GooglePlacesAutocompleteProps> &
-    React.RefAttributes<GooglePlacesAutocompleteRef>
+  React.RefAttributes<GooglePlacesAutocompleteRef>
 >;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jobber/react-native-google-places-autocomplete",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "Customizable Google Places autocomplete component for iOS and Android React-Native apps",
   "main": "GooglePlacesAutocomplete.js",
   "types": "GooglePlacesAutocomplete.d.ts",


### PR DESCRIPTION
# What's in this PR?
This PR adds a `listLoaderComponent` prop that will render in the modal while the request is pending.

### Why was this PR created?
This will improve the user experience by enabling a loading state.

### Quick summary of the changes you made.
- Added `listLoaderComponent` prop
- Show `listLoaderComponent` as `ListEmptyComponent` in modal `FlatlList` while a request is being made

### Any necessary explanation of decisions you made
- Only requests made for `onChangeText` of the `TextInputComp` will show the `listLoaderComponent`

## Before
- Could only show `listEmptyComponent`, which is useful for showing an empty state but not a loading state

## After
- Can have both an `listEmptyComponent` and `listLoadingComponent`

https://user-images.githubusercontent.com/5545625/118169019-b3c75580-b3e5-11eb-9fd8-1628b98e42a4.MP4


# QA
- [x] This has been QA'd by the PR owner
- [ ] This has been QA'd by an approver

## Device QA
- [ ] This has been tested on iOS
- [ ] This has been tested on Android

# References/Picture of cat
[JOB-31438](https://jobber.atlassian.net/browse/JOB-31438)
[Loosely based off this PR](https://github.com/FaridSafi/react-native-google-places-autocomplete/pull/720)
![cat](https://cataas.com/cat)