### PR TITLE
JOB-30707 Close modal when request fails

### DIFF
--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -500,6 +500,7 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
 
         setListLoaderDisplayed(false);
         if (request.status === 200) {
+          setListViewDisplayed(true);
           const responseJSON = JSON.parse(request.responseText);
           if (typeof responseJSON.predictions !== 'undefined') {
             // if (_isMounted === true) {
@@ -525,6 +526,7 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
             }
           }
         } else {
+            setListViewDisplayed(false);
           // console.warn("google places autocomplete: request could not be completed or has been aborted");
         }
       };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jobber/react-native-google-places-autocomplete",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "description": "Customizable Google Places autocomplete component for iOS and Android React-Native apps",
   "main": "GooglePlacesAutocomplete.js",
   "types": "GooglePlacesAutocomplete.d.ts",


### PR DESCRIPTION
- set `listViewedDisplayed` to `false` when the autocomplete request doesn't have a status of 200
- set `listViewedDisplayed` to `true` when the autocomplete request is a 200 again

Implementation and more detail with this PR https://github.com/GetJobber/jobber-mobile/pull/1065